### PR TITLE
fort_setup.sh: Don’t write config to the current dir and check if the directory used is writable

### DIFF
--- a/fort_setup.sh
+++ b/fort_setup.sh
@@ -78,11 +78,20 @@ if [ "$?" = "0" ] ; then
   TMP=""
 fi
 
+# Get the configuration directory
+CONF_DIR="$(dirname "${TALS_LOC}")"
+if [ ! -w "${CONF_DIR}" ]; then
+  CONF_DIR="/tmp/fort"
+  if [ ! -d "${CONF_DIR}" ]; then
+    mkdir -p "${CONF_DIR}"
+  fi
+fi
+
 # Declare variables
 GITHUB_TALS="https://raw.githubusercontent.com/NICMx/FORT-validator/master/examples/tal"
 ACCEPT="no"
 REPO_DIR="/var/cache/fort/repository"
-CONF_FILE="fort-config.json"
+CONF_FILE="${CONF_DIR}/fort-config.json"
 ARIN_TAL="https://www.arin.net/resources/manage/rpki/arin-rfc7730.tal"
 
 # Agree ARIN RPA. Exit on denial or unknown response, download otherwise.


### PR DESCRIPTION
The script tries to write config in the current directory, which isn’t always suitable nor writable:
```
pikachu ~ # ls -lh /usr/share/fort/
total 4,0K
drwxr-xr-x 2 fort root 4,0K 24 févr. 19:54 tal
pikachu ~ # su -s /bin/sh -c '/usr/libexec/fort/fort_setup.sh /usr/share/fort/tal/' fort

Please download and read ARIN Relying Party Agreement (RPA) from https://www.arin.net/resources/manage/rpki/rpa.pdf

Once you've read and if you agree ARIN RPA, type "yes" to proceed with ARIN's TAL download: yes

Fetching ARIN TAL...
--2020-02-24 19:56:19--  https://www.arin.net/resources/manage/rpki/arin-rfc7730.tal
Résolution de www.arin.net… 2001:500:4:201::47, 199.43.0.47
Connexion à www.arin.net|2001:500:4:201::47|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 455 [application/octet-stream]
Sauvegarde en : « /usr/share/fort/tal/arin-rfc7730.tal »

/usr/share/fort/tal/arin-rfc7730.tal         100%[==============================================================================================>]     455  --.-KB/s    ds 0s      

2020-02-24 19:56:21 (52,3 MB/s) — « /usr/share/fort/tal/arin-rfc7730.tal » sauvegardé [455/455]


Fetching the rest of the TALs

Fetching LACNIC TAL...
--2020-02-24 19:56:21--  https://raw.githubusercontent.com/NICMx/FORT-validator/master/examples/tal/lacnic.tal
Résolution de raw.githubusercontent.com… 151.101.236.133
Connexion à raw.githubusercontent.com|151.101.236.133|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 462 [text/plain]
Sauvegarde en : « /usr/share/fort/tal/lacnic.tal »

/usr/share/fort/tal/lacnic.tal               100%[==============================================================================================>]     462  --.-KB/s    ds 0s      

2020-02-24 19:56:21 (73,4 MB/s) — « /usr/share/fort/tal/lacnic.tal » sauvegardé [462/462]


Fetching RIPE TAL...
--2020-02-24 19:56:21--  https://raw.githubusercontent.com/NICMx/FORT-validator/master/examples/tal/ripe.tal
Résolution de raw.githubusercontent.com… 151.101.236.133
Connexion à raw.githubusercontent.com|151.101.236.133|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 441 [text/plain]
Sauvegarde en : « /usr/share/fort/tal/ripe.tal »

/usr/share/fort/tal/ripe.tal                 100%[==============================================================================================>]     441  --.-KB/s    ds 0s      

2020-02-24 19:56:22 (80,5 MB/s) — « /usr/share/fort/tal/ripe.tal » sauvegardé [441/441]


Fetching AFRINIC TAL...
--2020-02-24 19:56:22--  https://raw.githubusercontent.com/NICMx/FORT-validator/master/examples/tal/afrinic.tal
Résolution de raw.githubusercontent.com… 151.101.236.133
Connexion à raw.githubusercontent.com|151.101.236.133|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 448 [text/plain]
Sauvegarde en : « /usr/share/fort/tal/afrinic.tal »

/usr/share/fort/tal/afrinic.tal              100%[==============================================================================================>]     448  --.-KB/s    ds 0s      

2020-02-24 19:56:22 (53,3 MB/s) — « /usr/share/fort/tal/afrinic.tal » sauvegardé [448/448]


Fetching APNIC TAL...
--2020-02-24 19:56:23--  https://raw.githubusercontent.com/NICMx/FORT-validator/master/examples/tal/apnic.tal
Résolution de raw.githubusercontent.com… 151.101.236.133
Connexion à raw.githubusercontent.com|151.101.236.133|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 466 [text/plain]
Sauvegarde en : « /usr/share/fort/tal/apnic.tal »

/usr/share/fort/tal/apnic.tal                100%[==============================================================================================>]     466  --.-KB/s    ds 0s      

2020-02-24 19:56:23 (54,9 MB/s) — « /usr/share/fort/tal/apnic.tal » sauvegardé [466/466]

touch: impossible de faire un touch 'fort-config.json': Permission non accordée
/usr/libexec/fort/fort_setup.sh: ligne 121: fort-config.json: Permission non accordée
/usr/libexec/fort/fort_setup.sh: ligne 123: fort-config.json: Permission non accordée
/usr/libexec/fort/fort_setup.sh: ligne 125: fort-config.json: Permission non accordée
/usr/libexec/fort/fort_setup.sh: ligne 126: fort-config.json: Permission non accordée

------------------------------------------------------
--------------------   Success!   --------------------
------------------------------------------------------

- The five RIRs TAL's were downloaded to '/usr/share/fort/tal'.
- The directory /var/cache/fort/repository was created, so it can be used as the local repository.
- The configuration file 'fort-config.json' was created with the following content:
cat: fort-config.json: Permission non accordée

- This configuration file can be utilized with FORT validator, e.g.:
  $ fort -f "fort-config.json"
- Or its members can be utilized as FORT validator arguments, e.g.:
  $ fort --tal "/usr/share/fort/tal" --local-repository "/var/cache/fort/repository"

```

This patch tries to use the parent directory of the TALs directory, and uses `/tmp/fort/` as a fallback:
```
pikachu ~ # su -s /bin/sh -c '/usr/libexec/fort/fort_setup.sh /usr/share/fort/tal/' fort

Please download and read ARIN Relying Party Agreement (RPA) from https://www.arin.net/resources/manage/rpki/rpa.pdf

Once you've read and if you agree ARIN RPA, type "yes" to proceed with ARIN's TAL download: yes

Fetching ARIN TAL...
--2020-02-24 20:10:45--  https://www.arin.net/resources/manage/rpki/arin-rfc7730.tal
Résolution de www.arin.net… 2001:500:4:201::47, 199.43.0.47
Connexion à www.arin.net|2001:500:4:201::47|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 455 [application/octet-stream]
Sauvegarde en : « /usr/share/fort/tal/arin-rfc7730.tal »

/usr/share/fort/tal/arin-rfc7730.tal         100%[==============================================================================================>]     455  --.-KB/s    ds 0s      

2020-02-24 20:10:46 (55,0 MB/s) — « /usr/share/fort/tal/arin-rfc7730.tal » sauvegardé [455/455]


Fetching the rest of the TALs

Fetching LACNIC TAL...
--2020-02-24 20:10:46--  https://raw.githubusercontent.com/NICMx/FORT-validator/master/examples/tal/lacnic.tal
Résolution de raw.githubusercontent.com… 151.101.236.133
Connexion à raw.githubusercontent.com|151.101.236.133|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 462 [text/plain]
Sauvegarde en : « /usr/share/fort/tal/lacnic.tal »

/usr/share/fort/tal/lacnic.tal               100%[==============================================================================================>]     462  --.-KB/s    ds 0s      

2020-02-24 20:10:47 (39,2 MB/s) — « /usr/share/fort/tal/lacnic.tal » sauvegardé [462/462]


Fetching RIPE TAL...
--2020-02-24 20:10:47--  https://raw.githubusercontent.com/NICMx/FORT-validator/master/examples/tal/ripe.tal
Résolution de raw.githubusercontent.com… 151.101.236.133
Connexion à raw.githubusercontent.com|151.101.236.133|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 441 [text/plain]
Sauvegarde en : « /usr/share/fort/tal/ripe.tal »

/usr/share/fort/tal/ripe.tal                 100%[==============================================================================================>]     441  --.-KB/s    ds 0s      

2020-02-24 20:10:47 (35,6 MB/s) — « /usr/share/fort/tal/ripe.tal » sauvegardé [441/441]


Fetching AFRINIC TAL...
--2020-02-24 20:10:47--  https://raw.githubusercontent.com/NICMx/FORT-validator/master/examples/tal/afrinic.tal
Résolution de raw.githubusercontent.com… 151.101.236.133
Connexion à raw.githubusercontent.com|151.101.236.133|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 448 [text/plain]
Sauvegarde en : « /usr/share/fort/tal/afrinic.tal »

/usr/share/fort/tal/afrinic.tal              100%[==============================================================================================>]     448  --.-KB/s    ds 0s      

2020-02-24 20:10:48 (47,3 MB/s) — « /usr/share/fort/tal/afrinic.tal » sauvegardé [448/448]


Fetching APNIC TAL...
--2020-02-24 20:10:48--  https://raw.githubusercontent.com/NICMx/FORT-validator/master/examples/tal/apnic.tal
Résolution de raw.githubusercontent.com… 151.101.236.133
Connexion à raw.githubusercontent.com|151.101.236.133|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 466 [text/plain]
Sauvegarde en : « /usr/share/fort/tal/apnic.tal »

/usr/share/fort/tal/apnic.tal                100%[==============================================================================================>]     466  --.-KB/s    ds 0s      

2020-02-24 20:10:48 (54,1 MB/s) — « /usr/share/fort/tal/apnic.tal » sauvegardé [466/466]


------------------------------------------------------
--------------------   Success!   --------------------
------------------------------------------------------

- The five RIRs TAL's were downloaded to '/usr/share/fort/tal'.
- The directory /var/cache/fort/repository was created, so it can be used as the local repository.
- The configuration file '/usr/share/fort/fort-config.json' was created with the following content:
{ 
  "local-repository": "/var/cache/fort/repository",
  "tal": "/usr/share/fort/tal"
} 

- This configuration file can be utilized with FORT validator, e.g.:
  $ fort -f "/usr/share/fort/fort-config.json"
- Or its members can be utilized as FORT validator arguments, e.g.:
  $ fort --tal "/usr/share/fort/tal" --local-repository "/var/cache/fort/repository"

pikachu ~ # ls -lh /usr/share/fort/
total 8,0K
-rw-r--r-- 1 fort fort   89 24 févr. 20:10 fort-config.json
drwxr-xr-x 2 fort root 4,0K 24 févr. 19:56 tal
pikachu ~ # 
pikachu ~ # chown root /usr/share/fort/
pikachu ~ # su -s /bin/sh -c '/usr/libexec/fort/fort_setup.sh /usr/share/fort/tal/' fort

Please download and read ARIN Relying Party Agreement (RPA) from https://www.arin.net/resources/manage/rpki/rpa.pdf

Once you've read and if you agree ARIN RPA, type "yes" to proceed with ARIN's TAL download: yes

Fetching ARIN TAL...
--2020-02-24 20:19:56--  https://www.arin.net/resources/manage/rpki/arin-rfc7730.tal
Résolution de www.arin.net… 2001:500:4:201::47, 199.43.0.47
Connexion à www.arin.net|2001:500:4:201::47|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 455 [application/octet-stream]
Sauvegarde en : « /usr/share/fort/tal/arin-rfc7730.tal »

/usr/share/fort/tal/arin-rfc7730.tal         100%[==============================================================================================>]     455  --.-KB/s    ds 0s      

2020-02-24 20:19:57 (46,4 MB/s) — « /usr/share/fort/tal/arin-rfc7730.tal » sauvegardé [455/455]


Fetching the rest of the TALs

Fetching LACNIC TAL...
--2020-02-24 20:19:57--  https://raw.githubusercontent.com/NICMx/FORT-validator/master/examples/tal/lacnic.tal
Résolution de raw.githubusercontent.com… 151.101.236.133
Connexion à raw.githubusercontent.com|151.101.236.133|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 462 [text/plain]
Sauvegarde en : « /usr/share/fort/tal/lacnic.tal »

/usr/share/fort/tal/lacnic.tal               100%[==============================================================================================>]     462  --.-KB/s    ds 0s      

2020-02-24 20:19:58 (45,9 MB/s) — « /usr/share/fort/tal/lacnic.tal » sauvegardé [462/462]


Fetching RIPE TAL...
--2020-02-24 20:19:58--  https://raw.githubusercontent.com/NICMx/FORT-validator/master/examples/tal/ripe.tal
Résolution de raw.githubusercontent.com… 151.101.236.133
Connexion à raw.githubusercontent.com|151.101.236.133|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 441 [text/plain]
Sauvegarde en : « /usr/share/fort/tal/ripe.tal »

/usr/share/fort/tal/ripe.tal                 100%[==============================================================================================>]     441  --.-KB/s    ds 0s      

2020-02-24 20:19:58 (53,0 MB/s) — « /usr/share/fort/tal/ripe.tal » sauvegardé [441/441]


Fetching AFRINIC TAL...
--2020-02-24 20:19:58--  https://raw.githubusercontent.com/NICMx/FORT-validator/master/examples/tal/afrinic.tal
Résolution de raw.githubusercontent.com… 151.101.236.133
Connexion à raw.githubusercontent.com|151.101.236.133|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 448 [text/plain]
Sauvegarde en : « /usr/share/fort/tal/afrinic.tal »

/usr/share/fort/tal/afrinic.tal              100%[==============================================================================================>]     448  --.-KB/s    ds 0s      

2020-02-24 20:19:59 (56,6 MB/s) — « /usr/share/fort/tal/afrinic.tal » sauvegardé [448/448]


Fetching APNIC TAL...
--2020-02-24 20:19:59--  https://raw.githubusercontent.com/NICMx/FORT-validator/master/examples/tal/apnic.tal
Résolution de raw.githubusercontent.com… 151.101.236.133
Connexion à raw.githubusercontent.com|151.101.236.133|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 466 [text/plain]
Sauvegarde en : « /usr/share/fort/tal/apnic.tal »

/usr/share/fort/tal/apnic.tal                100%[==============================================================================================>]     466  --.-KB/s    ds 0s      

2020-02-24 20:19:59 (60,9 MB/s) — « /usr/share/fort/tal/apnic.tal » sauvegardé [466/466]


------------------------------------------------------
--------------------   Success!   --------------------
------------------------------------------------------

- The five RIRs TAL's were downloaded to '/usr/share/fort/tal'.
- The directory /var/cache/fort/repository was created, so it can be used as the local repository.
- The configuration file '/tmp/fort/repository/fort-config.json' was created with the following content:
{ 
  "local-repository": "/var/cache/fort/repository",
  "tal": "/usr/share/fort/tal"
} 

- This configuration file can be utilized with FORT validator, e.g.:
  $ fort -f "/tmp/fort/repository/fort-config.json"
- Or its members can be utilized as FORT validator arguments, e.g.:
  $ fort --tal "/usr/share/fort/tal" --local-repository "/var/cache/fort/repository"

pikachu ~ # ls -lh /tmp/fort/
total 4,0K
-rw-r--r-- 1 fort fort 89 24 févr. 20:19 fort-config.json
```