### PR TITLE
Don't set directory modtimes to match the source

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -882,6 +882,7 @@ set_default_values(void)
 		"--recursive",
 		"--delete",
 		"--times",
+		"--omit-dir-times",
 		"--contimeout=20",
 		"--timeout=15",
 		"--max-size=20MB",
@@ -891,6 +892,7 @@ set_default_values(void)
 
 	static char const *flat_rsync_args[] = {
 		"--times",
+		"--omit-dir-times",
 		"--contimeout=20",
 		"--timeout=15",
 		"--max-size=20MB",


### PR DESCRIPTION
When syncing against remote repositories, the modtimes of the remote directories is irrelevant. In the RRDP protocol the directory modtimes aren't signalled either. This should save some IOPS.