### PR TITLE
Treat X509_ALGOR as opaque structure

### DIFF
--- a/src/algorithm.c
+++ b/src/algorithm.c
@@ -61,22 +61,27 @@ validate_certificate_public_key_algorithm(X509_ALGOR *pa)
 int
 validate_certificate_public_key_algorithm_bgpsec(X509_ALGOR *pa)
 {
+	const ASN1_OBJECT *obj;
+	int parameter_type;
+	const void *parameter = NULL;
 	int nid;
 
-	nid = OBJ_obj2nid(pa->algorithm);
+	X509_ALGOR_get0(&obj, &parameter_type, &parameter, pa);
+
+	nid = OBJ_obj2nid(obj);
 
 	/* Validate algorithm and parameters (RFC 8608#section-3.1.1) */
 	if (nid != NID_X9_62_id_ecPublicKey)
 		return pr_val_err("Certificate's public key format is NID '%s', not id-ecPublicKey.",
 		    OBJ_nid2sn(nid));
 
-	if (pa->parameter == NULL)
+	if (parameter == NULL)
 		return pr_val_err("Certificate's public key algorithm MUST have parameters");
 
-	if (pa->parameter->type != V_ASN1_OBJECT)
+	if (parameter_type != V_ASN1_OBJECT)
 		return pr_val_err("Certificate's public key parameter type isn't valid");
 
-	nid = OBJ_obj2nid((ASN1_OBJECT *)pa->parameter->value.object);
+	nid = OBJ_obj2nid(parameter);
 	if (nid != NID_X9_62_prime256v1)
 		return pr_val_err("Certificate's public key format is NID '%s', not secp256r1 (a.k.a prime256v1).",
 		    OBJ_nid2sn(nid));

--- a/src/object/certificate.c
+++ b/src/object/certificate.c
@@ -160,7 +160,10 @@ validate_serial_number(X509 *cert)
 static int
 validate_signature_algorithm(X509 *cert)
 {
-	int nid = OBJ_obj2nid(X509_get0_tbs_sigalg(cert)->algorithm);
+	const ASN1_OBJECT *obj;
+	int nid;
+	X509_ALGOR_get0(&obj, NULL, NULL, X509_get0_tbs_sigalg(cert));
+	nid = OBJ_obj2nid(obj);
 	return validate_certificate_signature_algorithm(nid, "Certificate");
 }
 


### PR DESCRIPTION
Unfortunately, X509_ALGOR is still a public struct, and it only has the slightly awkward accessor X509_ALGOR_get0(), already used elsewhere in FORT. This converts two codepaths that reach into the struct to using X509_ALGOR_get0() so that X509_ALGOR can be made opaque in the future.