### PR TITLE
agregada rtrlib en la imagen de docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN ./configure && make && make install
 FROM alpine:latest
 
 # Install dependencies
-RUN apk --update --no-cache add openssl jansson rsync tini libxml2 libcurl
+RUN apk --update --no-cache add openssl jansson rsync tini libxml2 libcurl rtrlib
 
 # Install FORT
 COPY --from=builder /usr/local/bin/fort /usr/local/bin/fort


### PR DESCRIPTION
Hola,

Este PR propone agregar "rtrlib" como uno de los paquetes que se instalan en la imagen de Docker.

Este paquete agrega la herramienta "rtrclient" que se puede utilizar para extraer el listado actual de VRPs validadas de una manera mas eficiente y dinmámica que esperar que se genere el archivo CSV.
