### PR TITLE
Fix GCC 14 build failure and simplify XML error handler

### DIFF
--- a/src/xml/relax_ng.c
+++ b/src/xml/relax_ng.c
@@ -38,12 +38,7 @@ relax_ng_log_warn(void *ctx, const char *msg, ...)
 static void
 relax_ng_log_str_err(void *userData, const xmlError *error)
 {
-	char *ptr;
-
-	ptr = error->message;
-	if (ptr[strlen(ptr) - 1] == '\n')
-		ptr[strlen(ptr) - 1] = '\0';
-	pr_val_err("%s (at line %d)", ptr, error->line);
+	pr_val_err("%s (at line %d)", error->message, error->line);
 }
 
 /* Initialize global schema to parse RRDP files */

--- a/src/xml/relax_ng.c
+++ b/src/xml/relax_ng.c
@@ -36,7 +36,7 @@ relax_ng_log_warn(void *ctx, const char *msg, ...)
 }
 
 static void
-relax_ng_log_str_err(void *userData, xmlErrorPtr error)
+relax_ng_log_str_err(void *userData, const xmlError *error)
 {
 	char *ptr;
 


### PR DESCRIPTION
This was reported downstream at https://bugs.gentoo.org/928331.

The compilation fails with GCC 14 due to `incompatible-pointer-types` being an error by default.
```
$ ./autogen.sh
$ ./configure
$ make
Making all in src
make[1]: Entering directory '/root/FORT-validator/src'
make  all-am
make[2]: Entering directory '/root/FORT-validator/src'
gcc -DHAVE_CONFIG_H -I.    -Wall -Wpedantic -std=c99 -D_DEFAULT_SOURCE=1 -D_XOPEN_SOURCE=700 -D_BSD_SOURCE=1 -O2 -g  -I/usr/include/libxml2 -DBACKTRACE_ENABLED -g -O2 -MT xml/fort-relax_ng.o -MD -MP -MF xml/.deps/fort-relax_ng.Tpo -c -o xml/fort-relax_ng.o `test -f 'xml/relax_ng.c' || echo './'`xml/relax_ng.c
xml/relax_ng.c: In function 'relax_ng_parse':
xml/relax_ng.c:117:56: error: passing argument 2 of 'xmlTextReaderSetStructuredErrorHandler' from incompatible pointer type [-Wincompatible-pointer-types]
  117 |         xmlTextReaderSetStructuredErrorHandler(reader, relax_ng_log_str_err,
      |                                                        ^~~~~~~~~~~~~~~~~~~~
      |                                                        |
      |                                                        void (*)(void *, xmlError *) {aka void (*)(void *, struct _xmlError *)}
In file included from ./xml/relax_ng.h:4,
                 from xml/relax_ng.c:1:
/usr/include/libxml2/libxml/xmlreader.h:420:75: note: expected 'xmlStructuredErrorFunc' {aka 'void (*)(void *, const struct _xmlError *)'} but argument is of type 'void (*)(void *, xmlError *)' {aka 'void (*)(void *, struct _xmlError *)'}
  420 |                                                    xmlStructuredErrorFunc f,
      |                                                    ~~~~~~~~~~~~~~~~~~~~~~~^
make[2]: *** [Makefile:2712: xml/fort-relax_ng.o] Error 1
make[2]: Leaving directory '/root/FORT-validator/src'
make[1]: *** [Makefile:791: all] Error 2
make[1]: Leaving directory '/root/FORT-validator/src'
make: *** [Makefile:372: all-recursive] Error 1
```

Since we don't manipulate any struct members, I believe we can safely take a `const xmlError *` argument instead, as per [libxml2's documentation ](https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-xmlerror.html#xmlStructuredErrorFunc).

I also believe we can drop the string-termination handling, because C strings end with `\0` and therefore `ptr[strlen(ptr)-1]` is always `\0`.