### PR TITLE
Verify the signature on a self-signed TA cert against it's own pubkey

### DIFF
--- a/src/object/certificate.c
+++ b/src/object/certificate.c
@@ -467,6 +467,7 @@ static int
 validate_public_key(X509 *cert, enum cert_type type)
 {
 	X509_PUBKEY *pubkey;
+	EVP_PKEY *evppkey;
 	X509_ALGOR *pa;
 	int ok;
 	int error;
@@ -507,6 +508,10 @@ validate_public_key(X509 *cert, enum cert_type type)
 		error = validate_spki(pubkey);
 		if (error)
 			return error;
+		if ((evppkey = X509_get0_pubkey(cert)) == NULL)
+			return val_crypto_err("X509_get0_pubkey() returned NULL");
+		if (X509_verify(cert, evppkey) != 1)
+			return -EINVAL;
 	}
 
 	return 0;


### PR DESCRIPTION
`X509_verify_cert()` doesn't check the purported root certificate itself unless `X509_V_FLAG_CHECK_SS_SIGNATURE` is set.

The pubkey was compared against the TAL, so check that the signature is right as required by [RFC 6487, section 7.2](https://datatracker.ietf.org/doc/html/rfc6487#section-7.2), additional condition 1, applied to self-issued certs.

The error check looks weird, but OpenSSL 3 broke yet another API.

With help from Theo Buehler and Claudio Jeker