### PR TITLE
Shuffle the order in which Manifest entries are processed

### DIFF
--- a/src/object/manifest.c
+++ b/src/object/manifest.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #include "object/manifest.h"
 
 #include "algorithm.h"
@@ -192,14 +194,23 @@ build_rpp(struct Manifest *mft, struct rpki_uri *notif,
     struct rpki_uri *mft_uri, struct rpp **pp)
 {
 	char const *tal;
-	int i;
-	struct FileAndHash *fah;
+	int i, j;
+	struct FileAndHash *fah, *tmpfah;
 	struct rpki_uri *uri;
 	int error;
 
 	*pp = rpp_create();
 
 	tal = tal_get_file_name(validation_tal(state_retrieve()));
+
+	/* Fisher-Yates shuffle with modulo bias */
+	srand(time(NULL) ^ getpid());
+	for (i = 0; i < mft->fileList.list.count; i++) {
+		j = rand() % mft->fileList.list.count;
+		tmpfah = mft->fileList.list.array[j];
+		mft->fileList.list.array[j] = mft->fileList.list.array[i];
+		mft->fileList.list.array[i] = tmpfah;
+	}
 
 	for (i = 0; i < mft->fileList.list.count; i++) {
 		fah = mft->fileList.list.array[i];


### PR DESCRIPTION
Previously work items were enqueued in the order the CA intended them to appear on a Manifest. However, there is no obvious benefit to letting third parties decide the order in which objects are processed.

Instead, randomize the list of FileAndHashes, its ordering has no meaning anyway. As they say, a fox is not taken twice in the same snare