### PR TITLE
Generate all permutations of the list with equal probability

### DIFF
--- a/src/object/manifest.c
+++ b/src/object/manifest.c
@@ -205,8 +205,8 @@ build_rpp(struct Manifest *mft, struct rpki_uri *notif,
 
 	/* Fisher-Yates shuffle with modulo bias */
 	srand(time(NULL) ^ getpid());
-	for (i = 0; i < mft->fileList.list.count; i++) {
-		j = rand() % mft->fileList.list.count;
+	for (i = 0; i < mft->fileList.list.count - 1; i++) {
+		j = i + rand() % (mft->fileList.list.count - i);
 		tmpfah = mft->fileList.list.array[j];
 		mft->fileList.list.array[j] = mft->fileList.list.array[i];
 		mft->fileList.list.array[i] = tmpfah;

--- a/src/object/manifest.c
+++ b/src/object/manifest.c
@@ -198,15 +198,18 @@ build_rpp(struct Manifest *mft, struct rpki_uri *notif,
 	struct FileAndHash *fah, *tmpfah;
 	struct rpki_uri *uri;
 	int error;
+	unsigned int rnd;
+
+	rnd = time(NULL) ^ getpid();
 
 	*pp = rpp_create();
 
 	tal = tal_get_file_name(validation_tal(state_retrieve()));
 
 	/* Fisher-Yates shuffle with modulo bias */
-	srand(time(NULL) ^ getpid());
 	for (i = 0; i < mft->fileList.list.count - 1; i++) {
-		j = i + rand() % (mft->fileList.list.count - i);
+		rnd = rand_r(&rnd);
+		j = i + rnd % (mft->fileList.list.count - i);
 		tmpfah = mft->fileList.list.array[j];
 		mft->fileList.list.array[j] = mft->fileList.list.array[i];
 		mft->fileList.list.array[i] = tmpfah;


### PR DESCRIPTION
@botovq was kind enough to point out that although my earlier implementation produced random-ish ordering, it strictly speaking wasn't Fisher-Yates.

We need to ensure `j` is a random number between `i` and `list.count` see the second example in the 'Modern Algorithm'
https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle