### PR TITLE
Use HTTP compressed encoding when available

### DIFF
--- a/src/http/http.c
+++ b/src/http/http.c
@@ -153,6 +153,8 @@ http_easy_init(struct http_handler *handler, curl_off_t ims)
 
 	setopt_str(result, CURLOPT_USERAGENT, config_get_http_user_agent());
 
+	setopt_str(result, CURLOPT_ACCEPT_ENCODING, "");
+
 	setopt_long(result, CURLOPT_FOLLOWLOCATION, 1);
 	setopt_long(result, CURLOPT_MAXREDIRS, config_get_max_redirs());
 


### PR DESCRIPTION
This reduces network traffic by about 50%.

Without patch applied:
```
# systemd-run -p IPAccounting=yes --wait ./src/fort --tal=/etc/tals/ --mode=standalone --output.roa=/tmp/roa1 --local-repository=/home/fort1
Running as unit: run-u5244.service
Finished with result: success
Main processes terminated with: code=exited/status=0
Service runtime: 9min 243ms
CPU time consumed: 6min 59.190s
IP traffic received: 1.1G
IP traffic sent: 17.5M
```

With patch applied:
```
# systemd-run -p IPAccounting=yes --wait ./src/fort --tal=/etc/tals/ --mode=standalone --output.roa=/tmp/roa2 --local-repository=/home/fort-http-compression
Running as unit: run-u5246.service
Finished with result: success
Main processes terminated with: code=exited/status=0
Service runtime: 8min 44.294s
CPU time consumed: 10min 44.351s
IP traffic received: 572.1M
IP traffic sent: 8.3M
```

Comparison with `rpki-client` which uses HTTP compression when available:
```
# systemd-run -p IPAccounting=yes --wait rpki-client -v -d /home/rpkiclient /tmp
Running as unit: run-u5208.service
Finished with result: success
Main processes terminated with: code=exited/status=0
Service runtime: 7min 17.549s
CPU time consumed: 5min 27.936s
IP traffic received: 547.3M
IP traffic sent: 8.6M
```