### PR TITLE
Improve compliance with RFC 9589

### DIFF
--- a/src/asn1/oid.h
+++ b/src/asn1/oid.h
@@ -31,7 +31,6 @@ typedef asn_oid_arc_t OID[];
 #define OID_CONTENT_TYPE_ATTR        { 1, 2, 840, 113549, 1, 9, 3 }
 #define OID_MESSAGE_DIGEST_ATTR      { 1, 2, 840, 113549, 1, 9, 4 }
 #define OID_SIGNING_TIME_ATTR        { 1, 2, 840, 113549, 1, 9, 5 }
-#define OID_BINARY_SIGNING_TIME_ATTR { 1, 2, 840, 113549, 1, 9, 16, 2, 46 }
 
 #define OID_ROA                      { 1, 2, 840, 113549, 1, 9, 16, 1, 24 }
 #define OID_MANIFEST                 { 1, 2, 840, 113549, 1, 9, 16, 1, 26 }

--- a/src/asn1/signed_data.c
+++ b/src/asn1/signed_data.c
@@ -14,7 +14,6 @@
 static const OID oid_cta = OID_CONTENT_TYPE_ATTR;
 static const OID oid_mda = OID_MESSAGE_DIGEST_ATTR;
 static const OID oid_sta = OID_SIGNING_TIME_ATTR;
-static const OID oid_bsta = OID_BINARY_SIGNING_TIME_ATTR;
 
 void
 eecert_init(struct ee_cert *ee, STACK_OF(X509_CRL) *crls, bool force_inherit)
@@ -168,7 +167,6 @@ validate_signed_attrs(struct SignerInfo *sinfo, EncapsulatedContentInfo_t *eci)
 	bool content_type_found = false;
 	bool message_digest_found = false;
 	bool signing_time_found = false;
-	bool binary_signing_time_found = false;
 	int error;
 
 	if (sinfo->signedAttrs == NULL)
@@ -218,15 +216,6 @@ validate_signed_attrs(struct SignerInfo *sinfo, EncapsulatedContentInfo_t *eci)
 			}
 			error = 0; /* No validations needed for now. */
 			signing_time_found = true;
-
-		} else if (ARCS_EQUAL_OIDS(&attrType, oid_bsta)) {
-			if (binary_signing_time_found) {
-				pr_val_err("Multiple BinarySigningTimes found.");
-				goto illegal_attrType;
-			}
-			error = 0; /* No validations needed for now. */
-			binary_signing_time_found = true;
-
 		} else {
 			/* rfc6488#section-3.1.g */
 			pr_val_err("Illegal attrType OID in SignerInfo.");
@@ -244,6 +233,8 @@ validate_signed_attrs(struct SignerInfo *sinfo, EncapsulatedContentInfo_t *eci)
 		return pr_val_err("SignerInfo lacks a ContentType attribute.");
 	if (!message_digest_found)
 		return pr_val_err("SignerInfo lacks a MessageDigest attribute.");
+	if (!signing_time_found)
+		return pr_val_err("SignerInfo lacks a SigningTime attribute.");
 
 	return 0;
 


### PR DESCRIPTION
As of 9589, the CMS SigningTime attribute is mandatory and the CMS BinarySigningTime attribute is forbidden.

Question for @ydahhrk does `oid2arcs().MAX_ARCS` need to be reduced by 1, because 1 OID declaration is removed?