### PR TITLE
Add rsync transfer timeout

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -65,6 +65,7 @@ description: Guide to use arguments of FORT Validator.
 	51. [`--rsync.priority`](#--rsyncpriority)
 	53. [`--rsync.retry.count`](#--rsyncretrycount)
 	54. [`--rsync.retry.interval`](#--rsyncretryinterval)
+	40. [`--rsync.transfer-timeout`](#--rsynctransfer-timeout)
 	55. [`--configuration-file`](#--configuration-file)
 	56. [`rsync.program`](#rsyncprogram)
 	57. [`rsync.arguments-recursive`](#rsyncarguments-recursive)
@@ -103,6 +104,7 @@ description: Guide to use arguments of FORT Validator.
 	[--rsync.priority=<unsigned integer>]
 	[--rsync.retry.count=<unsigned integer>]
 	[--rsync.retry.interval=<unsigned integer>]
+	[--rsync.transfer-timeout=<unsigned integer>]
 	[--http.enabled=true|false]
 	[--http.priority=<unsigned integer>]
 	[--http.retry.count=<unsigned integer>]
@@ -931,6 +933,17 @@ Whenever is necessary to execute an RSYNC, the validator will try at least one t
 
 Period of time (in seconds) to wait between each retry to execute an RSYNC.
 
+### `--rsync.transfer-timeout`
+
+- **Type:** Integer
+- **Availability:** `argv` and JSON
+- **Default:** 900
+- **Range:** [0, [`UINT_MAX`](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html)]
+
+Maximum time in seconds that the rsync transfer can last.
+
+Once the connection is established with the server, the request will last a maximum of `rsync.transfer-timeout` seconds. A value of 0 means unlimited time.
+
 ### `--configuration-file`
 
 - **Type:** String (Path to file)
@@ -974,6 +987,7 @@ The configuration options are mostly the same as the ones from the `argv` interf
 			"<a href="#--rsyncretrycount">count</a>": 1,
 			"<a href="#--rsyncretryinterval">interval</a>": 4
 		},
+		"<a href="#--rsynctransfer-timeout">transfer-timeout</a>": 0,
 		"<a href="#rsyncprogram">program</a>": "rsync",
 		"<a href="#rsyncarguments-recursive">arguments-recursive</a>": [
 			"-rtz",

--- a/examples/config.json
+++ b/examples/config.json
@@ -56,6 +56,7 @@
       "count": 2,
       "interval": 5
     },
+    "transfer-timeout": 900,
     "program": "rsync",
     "arguments-recursive": [
       "--recursive",

--- a/man/fort.8
+++ b/man/fort.8
@@ -1009,6 +1009,18 @@ By default, the value is \fI5\fR.
 .RE
 .P
 
+.B \-\-rsync.transfer\-timeout=\fIUNSIGNED_INTEGER\fR
+.RS 4
+Maximum time in seconds that the rsync process can last.
+.P
+Once the connection is established with the server, the request will last a
+maximum of \fBrsync.transfer-timeout\fR seconds. A value of \fI0\fR means
+unlimited time (default value).
+.P
+By default, it has a value of \fI900\fR.
+.RE
+.P
+
 .B \-\-output.roa=\fIFILE\fR
 .RS 4
 File where the ROAs will be printed in the configured format (see

--- a/src/config.c
+++ b/src/config.c
@@ -86,6 +86,7 @@ struct rpki_config {
 			/* Interval (in seconds) between each retry */
 			unsigned int interval;
 		} retry;
+		unsigned int transfer_timeout;
 		char *program;
 		struct {
 			struct string_array flat; /* Deprecated */
@@ -486,6 +487,14 @@ static const struct option_field options[] = {
 		/* Unlimited */
 		.max = 0,
 		.deprecated = true,
+	}, {
+		.id = 3008,
+		.name = "rsync.transfer-timeout",
+		.type = &gt_uint,
+		.offset = offsetof(struct rpki_config, rsync.transfer_timeout),
+		.doc = "Maximum transfer time before killing the rsync process",
+		.min = 0,
+		.max = UINT_MAX,
 	},
 
 	/* HTTP requests parameters */
@@ -946,6 +955,7 @@ set_default_values(void)
 	rpki_config.rsync.strategy = pstrdup("<deprecated>");
 	rpki_config.rsync.retry.count = 1;
 	rpki_config.rsync.retry.interval = 4;
+	rpki_config.rsync.transfer_timeout = 900;
 	rpki_config.rsync.program = pstrdup("rsync");
 	string_array_init(&rpki_config.rsync.args.flat,
 	    flat_rsync_args, ARRAY_LEN(flat_rsync_args));
@@ -1340,6 +1350,12 @@ unsigned int
 config_get_rsync_retry_interval(void)
 {
 	return rpki_config.rsync.retry.interval;
+}
+
+long
+config_get_rsync_transfer_timeout(void)
+{
+	return rpki_config.rsync.transfer_timeout;
 }
 
 char *

--- a/src/config.h
+++ b/src/config.h
@@ -44,6 +44,7 @@ bool config_get_rsync_enabled(void);
 unsigned int config_get_rsync_priority(void);
 unsigned int config_get_rsync_retry_count(void);
 unsigned int config_get_rsync_retry_interval(void);
+long config_get_rsync_transfer_timeout(void);
 char *config_get_rsync_program(void);
 struct string_array const *config_get_rsync_args(void);
 bool config_get_http_enabled(void);


### PR DESCRIPTION
Using a widowed pipe the implementation can wait for `timeout` to expire or to receive `EOF`.

Default transfer timeout is 900, same as rpki-client. Routinator uses 300.