### PR TITLE
Set default HTTP transfer timeout to 900

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -704,7 +704,7 @@ The value specified (either by the argument or the default value) is utilized in
 
 - **Type:** Integer
 - **Availability:** `argv` and JSON
-- **Default:** 0
+- **Default:** 900
 - **Range:** [0, [`UINT_MAX`](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html)]
 
 _**All requests are made using HTTPS, verifying the peer and the certificate name vs host**_

--- a/man/fort.8
+++ b/man/fort.8
@@ -813,7 +813,7 @@ unlimited time (default value).
 The value specified (either by the argument or the default value) is utilized
 in libcurl’s option \fICURLOPT_TIMEOUT\fR.
 .P
-By default, it has a value of \fI0\fR.
+By default, it has a value of \fI900\fR.
 .RE
 .P
 

--- a/src/config.c
+++ b/src/config.c
@@ -960,7 +960,7 @@ set_default_values(void)
 	rpki_config.http.user_agent = pstrdup(PACKAGE_NAME "/" PACKAGE_VERSION);
 	rpki_config.http.max_redirs = 10;
 	rpki_config.http.connect_timeout = 30;
-	rpki_config.http.transfer_timeout = 0;
+	rpki_config.http.transfer_timeout = 900;
 	rpki_config.http.low_speed_limit = 100000;
 	rpki_config.http.low_speed_time = 10;
 	rpki_config.http.max_file_size = 1000000000;


### PR DESCRIPTION
There is no point in letting HTTPS connections go on forever and ever.

Introduce sane default limit of 900 (same as rpki-client). If HTTPS fails rsync will be used.