### PR TITLE
Exclude hidden files and directories when synchronizing via Rsync

### DIFF
--- a/src/rsync.c
+++ b/src/rsync.c
@@ -285,6 +285,7 @@ execvp_rsync(struct rsync_task *task, int fds[2][2])
 		args[i++] = "--contimeout=20";
 		args[i++] = "--max-size=20MB";
 		args[i++] = "--timeout=15";
+		args[i++] = "--exclude=.*";
 		args[i++] = "--include=*/";
 		args[i++] = "--include=*.cer";
 		args[i++] = "--include=*.crl";


### PR DESCRIPTION
According to RFC 9286 section 4.2.2, filenames in the RPKI cannot start with a dot. And RFC 6481 section 1.1 describes the concept of a publication point as a "directory in a _publicly_ accessible filesystem". From there it follows there is no need to transfer hidden files and directories. This may help in avoiding exposure to intermediate states (e.g., `/a/.~tmp~/b.roa`).

Spotted recently:

```
rsync: executing rsync -rtO --no-motd --min-size=100 --max-size=8000000
--contimeout=15 --timeout=30 --include=*/ --include=*.cer
--include=*.crl --include=*.mft --include=*.roa --include=*.asa
--include=*.tak --include=*.spl --include=*.gbr --exclude=*
rsync://rpki-rps.cnnic.cn/repo/ cache/rpki-rps.cnnic.cn/repo
directory has vanished: "A1065585389265289217/0/.~tmp~" (in repo)
file has vanished: "A1065583221972402179/0/.~tmp~/1BF077990B3EF2F79478B657B4C3AF7BDEB8F260.crl" (in repo)
file has vanished: "A1065583221972402179/0/.~tmp~/1BF077990B3EF2F79478B657B4C3AF7BDEB8F260.mft" (in repo)
file has vanished: "A1065583221972402179/0/.~tmp~/3130332e3135322e3138362e302f32332d3233203d3e20313339313339.roa" (in repo)
file has vanished: "A1065583221972402179/0/.~tmp~/3130332e3135322e3138362e302f32332d3233203d3e2034353338.roa" (in repo)
rsync warning: some files vanished before they could be transferred (code 24) at main.c(1852) [generator=3.4.1]
```

Ported from rpki-client https://github.com/openbsd/src/commit/d5fd420d8eebc7706279067661329674127fe31e