### PR TITLE
Exclude hidden files and directories when synchronizing via Rsync

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -948,6 +948,7 @@ set_default_values(void)
 
 		"--contimeout=20", "--max-size=20MB", "--timeout=15",
 
+		"--exclude=.*",
 		"--include=*/", "--include=*.cer", "--include=*.crl",
 		"--include=*.gbr", "--include=*.mft", "--include=*.roa",
 		"--exclude=*",


### PR DESCRIPTION
According to RFC 9286 section 4.2.2, filenames in the RPKI cannot start with a dot. And RFC 6481 section 1.1 describes the concept of a publication point as a "directory in a publicly accessible filesystem". From there it follows there is no need to transfer hidden files and directories. This may help in avoiding exposure to intermediate states (e.g., `/a/.~tmp~/b.roa`).

See https://github.com/NICMx/FORT-validator/pull/174